### PR TITLE
cache BIP143/ZIP243 intermediate sighash digests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runonflux/utxo-lib",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "engines": {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -32,6 +32,8 @@ function Transaction (network = networks.bitcoin) {
   this.ins = []
   this.outs = []
   this.network = network
+  // lazily populated cache for BIP143/ZIP243 intermediate hashes, see getPrevoutHash
+  this.__sighashCache = null
   if (coins.isZcash(network)) {
     // ZCash version >= 2
     this.joinsplits = []
@@ -387,6 +389,8 @@ Transaction.prototype.addInput = function (hash, index, sequence, scriptSig) {
     sequence = Transaction.DEFAULT_SEQUENCE
   }
 
+  this.invalidateHashCache()
+
   // Add the input and return the input's index
   return (this.ins.push({
     hash: hash,
@@ -399,6 +403,8 @@ Transaction.prototype.addInput = function (hash, index, sequence, scriptSig) {
 
 Transaction.prototype.addOutput = function (scriptPubKey, value) {
   typeforce(types.tuple(types.Buffer, types.Satoshi), arguments)
+
+  this.invalidateHashCache()
 
   // Add the output and return the output's index
   return (this.outs.push({
@@ -698,29 +704,52 @@ Transaction.prototype.getBlake2bHash = function (bufferToHash, personalization) 
 }
 
 /**
+ * Invalidate the cached BIP143/ZIP243 intermediate hashes (hashPrevouts,
+ * hashSequence, hashOutputs). Called automatically by addInput/addOutput.
+ * Code that mutates ins/outs fields directly must call this afterwards.
+ */
+Transaction.prototype.invalidateHashCache = function () {
+  this.__sighashCache = null
+}
+
+/**
  * Build a hash for all or none of the transaction inputs depending on the hashtype
+ *
+ * The digest commits to all input outpoints, so it is a constant of the
+ * transaction for a given hashType and is cached after the first call
+ * (recomputing it for every input made signing O(n^2) in the input count).
  * @param hashType
  * @returns double SHA-256, 256-bit BLAKE2b hash or 256-bit zero if doesn't apply
  */
 Transaction.prototype.getPrevoutHash = function (hashType) {
   if (!(hashType & Transaction.SIGHASH_ANYONECANPAY)) {
-    var bufferWriter = new BufferWriter(36 * this.ins.length)
+    var cache = this.__sighashCache = this.__sighashCache || {}
+    var cacheKey = 'prevouts:' + hashType
+    if (!cache[cacheKey]) {
+      var bufferWriter = new BufferWriter(36 * this.ins.length)
 
-    this.ins.forEach(function (txIn) {
-      bufferWriter.writeSlice(txIn.hash)
-      bufferWriter.writeUInt32(txIn.index)
-    })
+      this.ins.forEach(function (txIn) {
+        bufferWriter.writeSlice(txIn.hash)
+        bufferWriter.writeUInt32(txIn.index)
+      })
 
-    if (coins.isZcash(this.network)) {
-      return this.getBlake2bHash(bufferWriter.getBuffer(), 'ZcashPrevoutHash')
+      if (coins.isZcash(this.network)) {
+        cache[cacheKey] = this.getBlake2bHash(bufferWriter.getBuffer(), 'ZcashPrevoutHash')
+      } else {
+        cache[cacheKey] = this.network.hashFunctions.transaction(bufferWriter.getBuffer())
+      }
     }
-    return this.network.hashFunctions.transaction(bufferWriter.getBuffer())
+    // return a copy so callers keep owning the returned buffer
+    return Buffer.from(cache[cacheKey])
   }
   return ZERO
 }
 
 /**
  * Build a hash for all or none of the transactions inputs sequence numbers depending on the hashtype
+ *
+ * The digest commits to all input sequence numbers, so it is a constant of
+ * the transaction for a given hashType and is cached after the first call.
  * @param hashType
  * @returns double SHA-256, 256-bit BLAKE2b hash or 256-bit zero if doesn't apply
  */
@@ -728,22 +757,34 @@ Transaction.prototype.getSequenceHash = function (hashType) {
   if (!(hashType & Transaction.SIGHASH_ANYONECANPAY) &&
     (hashType & 0x1f) !== Transaction.SIGHASH_SINGLE &&
     (hashType & 0x1f) !== Transaction.SIGHASH_NONE) {
-    var bufferWriter = new BufferWriter(4 * this.ins.length)
+    var cache = this.__sighashCache = this.__sighashCache || {}
+    var cacheKey = 'sequence:' + hashType
+    if (!cache[cacheKey]) {
+      var bufferWriter = new BufferWriter(4 * this.ins.length)
 
-    this.ins.forEach(function (txIn) {
-      bufferWriter.writeUInt32(txIn.sequence)
-    })
+      this.ins.forEach(function (txIn) {
+        bufferWriter.writeUInt32(txIn.sequence)
+      })
 
-    if (coins.isZcash(this.network)) {
-      return this.getBlake2bHash(bufferWriter.getBuffer(), 'ZcashSequencHash')
+      if (coins.isZcash(this.network)) {
+        cache[cacheKey] = this.getBlake2bHash(bufferWriter.getBuffer(), 'ZcashSequencHash')
+      } else {
+        cache[cacheKey] = this.network.hashFunctions.transaction(bufferWriter.getBuffer())
+      }
     }
-    return this.network.hashFunctions.transaction(bufferWriter.getBuffer())
+    // return a copy so callers keep owning the returned buffer
+    return Buffer.from(cache[cacheKey])
   }
   return ZERO
 }
 
 /**
  * Build a hash for one, all or none of the transaction outputs depending on the hashtype
+ *
+ * For hashtypes other than SIGHASH_SINGLE the digest commits to all outputs
+ * and is independent of inIndex, so it is a constant of the transaction for
+ * a given hashType and is cached after the first call. The SIGHASH_SINGLE
+ * digest depends on inIndex and is never cached.
  * @param hashType
  * @param inIndex
  * @returns double SHA-256, 256-bit BLAKE2b hash or 256-bit zero if doesn't apply
@@ -751,22 +792,29 @@ Transaction.prototype.getSequenceHash = function (hashType) {
 Transaction.prototype.getOutputsHash = function (hashType, inIndex) {
   var bufferWriter
   if ((hashType & 0x1f) !== Transaction.SIGHASH_SINGLE && (hashType & 0x1f) !== Transaction.SIGHASH_NONE) {
-    // Find out the size of the outputs and write them
-    var txOutsSize = this.outs.reduce(function (sum, output) {
-      return sum + 8 + varSliceSize(output.script)
-    }, 0)
+    var cache = this.__sighashCache = this.__sighashCache || {}
+    var cacheKey = 'outputs:' + hashType
+    if (!cache[cacheKey]) {
+      // Find out the size of the outputs and write them
+      var txOutsSize = this.outs.reduce(function (sum, output) {
+        return sum + 8 + varSliceSize(output.script)
+      }, 0)
 
-    bufferWriter = new BufferWriter(txOutsSize)
+      bufferWriter = new BufferWriter(txOutsSize)
 
-    this.outs.forEach(function (out) {
-      bufferWriter.writeUInt64(out.value)
-      bufferWriter.writeVarSlice(out.script)
-    })
+      this.outs.forEach(function (out) {
+        bufferWriter.writeUInt64(out.value)
+        bufferWriter.writeVarSlice(out.script)
+      })
 
-    if (coins.isZcash(this.network)) {
-      return this.getBlake2bHash(bufferWriter.getBuffer(), 'ZcashOutputsHash')
+      if (coins.isZcash(this.network)) {
+        cache[cacheKey] = this.getBlake2bHash(bufferWriter.getBuffer(), 'ZcashOutputsHash')
+      } else {
+        cache[cacheKey] = this.network.hashFunctions.transaction(bufferWriter.getBuffer())
+      }
     }
-    return this.network.hashFunctions.transaction(bufferWriter.getBuffer())
+    // return a copy so callers keep owning the returned buffer
+    return Buffer.from(cache[cacheKey])
   } else if ((hashType & 0x1f) === Transaction.SIGHASH_SINGLE && inIndex < this.outs.length) {
     // Write only the output specified in inIndex
     var output = this.outs[inIndex]

--- a/test/sighash_cache.js
+++ b/test/sighash_cache.js
@@ -1,0 +1,293 @@
+/* global describe, it */
+
+var assert = require('assert')
+var BufferWriter = require('../src/bufferWriter')
+var bcrypto = require('../src/crypto')
+var bscript = require('../src/script')
+var btemplates = require('../src/templates')
+var coins = require('../src/coins')
+var networks = require('../src/networks')
+var varuint = require('varuint-bitcoin')
+var ECPair = require('../src/ecpair')
+var ECSignature = require('../src/ecsignature')
+var Transaction = require('../src/transaction')
+var TransactionBuilder = require('../src/transaction_builder')
+
+var SIGHASH_ALL = Transaction.SIGHASH_ALL
+var SIGHASH_NONE = Transaction.SIGHASH_NONE
+var SIGHASH_SINGLE = Transaction.SIGHASH_SINGLE
+var SIGHASH_ANYONECANPAY = Transaction.SIGHASH_ANYONECANPAY
+var VALUE = 872000000
+var ZERO = Buffer.alloc(32, 0)
+
+function varSliceSize (someScript) {
+  var length = someScript.length
+  return varuint.encodingLength(length) + length
+}
+
+// independent reference implementations of the three digests, mirroring
+// BIP143/ZIP243 — used to check the cached getters against first principles
+function referencePrevoutHash (tx) {
+  var bufferWriter = new BufferWriter(36 * tx.ins.length)
+  tx.ins.forEach(function (txIn) {
+    bufferWriter.writeSlice(txIn.hash)
+    bufferWriter.writeUInt32(txIn.index)
+  })
+  if (coins.isZcash(tx.network)) {
+    return tx.getBlake2bHash(bufferWriter.getBuffer(), 'ZcashPrevoutHash')
+  }
+  return tx.network.hashFunctions.transaction(bufferWriter.getBuffer())
+}
+
+function referenceSequenceHash (tx) {
+  var bufferWriter = new BufferWriter(4 * tx.ins.length)
+  tx.ins.forEach(function (txIn) {
+    bufferWriter.writeUInt32(txIn.sequence)
+  })
+  if (coins.isZcash(tx.network)) {
+    return tx.getBlake2bHash(bufferWriter.getBuffer(), 'ZcashSequencHash')
+  }
+  return tx.network.hashFunctions.transaction(bufferWriter.getBuffer())
+}
+
+function referenceOutputsHash (tx) {
+  var txOutsSize = tx.outs.reduce(function (sum, output) {
+    return sum + 8 + varSliceSize(output.script)
+  }, 0)
+  var bufferWriter = new BufferWriter(txOutsSize)
+  tx.outs.forEach(function (out) {
+    bufferWriter.writeUInt64(out.value)
+    bufferWriter.writeVarSlice(out.script)
+  })
+  if (coins.isZcash(tx.network)) {
+    return tx.getBlake2bHash(bufferWriter.getBuffer(), 'ZcashOutputsHash')
+  }
+  return tx.network.hashFunctions.transaction(bufferWriter.getBuffer())
+}
+
+function deterministicKeyPair (fillByte, network) {
+  return ECPair.makeRandom({
+    network: network,
+    rng: function () { return Buffer.alloc(32, fillByte) }
+  })
+}
+
+function buildTestTransaction (network, numIns, numOuts) {
+  var tx = new Transaction(network)
+  if (coins.isZcash(network)) {
+    tx.version = 4
+    tx.overwintered = 1
+    tx.versionGroupId = 0x892f2085
+  }
+  var i
+  for (i = 0; i < numIns; i++) {
+    tx.addInput(bcrypto.sha256(Buffer.from('input-' + i)), i)
+  }
+  var outputScript = btemplates.pubKeyHash.output.encode(bcrypto.hash160(Buffer.from('pubkey-placeholder')))
+  for (i = 0; i < numOuts; i++) {
+    tx.addOutput(outputScript, VALUE + i)
+  }
+  return tx
+}
+
+describe('Transaction sighash digest caching', function () {
+  var testNetworks = { flux: networks.flux, bitcoin: networks.bitcoin }
+
+  Object.keys(testNetworks).forEach(function (name) {
+    var network = testNetworks[name]
+
+    describe(name, function () {
+      it('cached digests equal independent reference implementations', function () {
+        var tx = buildTestTransaction(network, 5, 2)
+
+        // call repeatedly — first call populates the cache, rest must serve from it
+        for (var i = 0; i < 3; i++) {
+          assert.deepStrictEqual(tx.getPrevoutHash(SIGHASH_ALL), referencePrevoutHash(tx))
+          assert.deepStrictEqual(tx.getSequenceHash(SIGHASH_ALL), referenceSequenceHash(tx))
+          assert.deepStrictEqual(tx.getOutputsHash(SIGHASH_ALL, 0), referenceOutputsHash(tx))
+        }
+      })
+
+      it('warm cache equals cold instance computation', function () {
+        var warm = buildTestTransaction(network, 4, 2)
+        // warm up the cache
+        warm.getPrevoutHash(SIGHASH_ALL)
+        warm.getSequenceHash(SIGHASH_ALL)
+        warm.getOutputsHash(SIGHASH_ALL, 0)
+
+        var cold = buildTestTransaction(network, 4, 2)
+        assert.deepStrictEqual(warm.getPrevoutHash(SIGHASH_ALL), cold.getPrevoutHash(SIGHASH_ALL))
+        assert.deepStrictEqual(warm.getSequenceHash(SIGHASH_ALL), cold.getSequenceHash(SIGHASH_ALL))
+        assert.deepStrictEqual(warm.getOutputsHash(SIGHASH_ALL, 0), cold.getOutputsHash(SIGHASH_ALL, 0))
+      })
+
+      it('mutating a returned digest does not poison the cache', function () {
+        var tx = buildTestTransaction(network, 3, 2)
+        var first = tx.getPrevoutHash(SIGHASH_ALL)
+        var expected = Buffer.from(first)
+        first.fill(0)
+        assert.deepStrictEqual(tx.getPrevoutHash(SIGHASH_ALL), expected)
+      })
+
+      it('addInput invalidates the cache', function () {
+        var tx = buildTestTransaction(network, 3, 2)
+        var before = tx.getPrevoutHash(SIGHASH_ALL)
+        var beforeSequence = tx.getSequenceHash(SIGHASH_ALL)
+
+        tx.addInput(bcrypto.sha256(Buffer.from('input-extra')), 99)
+
+        assert.notDeepStrictEqual(tx.getPrevoutHash(SIGHASH_ALL), before)
+        assert.notDeepStrictEqual(tx.getSequenceHash(SIGHASH_ALL), beforeSequence)
+        assert.deepStrictEqual(tx.getPrevoutHash(SIGHASH_ALL), referencePrevoutHash(tx))
+        assert.deepStrictEqual(tx.getSequenceHash(SIGHASH_ALL), referenceSequenceHash(tx))
+      })
+
+      it('addOutput invalidates the cache', function () {
+        var tx = buildTestTransaction(network, 3, 2)
+        var before = tx.getOutputsHash(SIGHASH_ALL, 0)
+
+        var outputScript = btemplates.pubKeyHash.output.encode(bcrypto.hash160(Buffer.from('another-pubkey')))
+        tx.addOutput(outputScript, VALUE * 2)
+
+        assert.notDeepStrictEqual(tx.getOutputsHash(SIGHASH_ALL, 0), before)
+        assert.deepStrictEqual(tx.getOutputsHash(SIGHASH_ALL, 0), referenceOutputsHash(tx))
+      })
+
+      it('SIGHASH_SINGLE outputs digest depends on inIndex and is never cached', function () {
+        var tx = buildTestTransaction(network, 3, 2)
+        // warm the SIGHASH_ALL cache first to ensure no cross-contamination
+        tx.getOutputsHash(SIGHASH_ALL, 0)
+
+        var single0 = tx.getOutputsHash(SIGHASH_SINGLE, 0)
+        var single1 = tx.getOutputsHash(SIGHASH_SINGLE, 1)
+        assert.notDeepStrictEqual(single0, single1)
+
+        var cold = buildTestTransaction(network, 3, 2)
+        assert.deepStrictEqual(single0, cold.getOutputsHash(SIGHASH_SINGLE, 0))
+        assert.deepStrictEqual(single1, cold.getOutputsHash(SIGHASH_SINGLE, 1))
+        // out of range single returns ZERO
+        assert.deepStrictEqual(tx.getOutputsHash(SIGHASH_SINGLE, 5), ZERO)
+      })
+
+      it('hashType variants keep their not-applicable ZERO results', function () {
+        var tx = buildTestTransaction(network, 3, 2)
+        tx.getPrevoutHash(SIGHASH_ALL) // warm cache
+
+        assert.deepStrictEqual(tx.getPrevoutHash(SIGHASH_ALL | SIGHASH_ANYONECANPAY), ZERO)
+        assert.deepStrictEqual(tx.getSequenceHash(SIGHASH_ALL | SIGHASH_ANYONECANPAY), ZERO)
+        assert.deepStrictEqual(tx.getSequenceHash(SIGHASH_SINGLE), ZERO)
+        assert.deepStrictEqual(tx.getSequenceHash(SIGHASH_NONE), ZERO)
+        assert.deepStrictEqual(tx.getOutputsHash(SIGHASH_NONE, 0), ZERO)
+      })
+
+      it('clone starts with an empty cache', function () {
+        var tx = buildTestTransaction(network, 3, 2)
+        tx.getPrevoutHash(SIGHASH_ALL)
+        var clone = tx.clone()
+        assert.strictEqual(clone.__sighashCache, null)
+        assert.deepStrictEqual(clone.getPrevoutHash(SIGHASH_ALL), tx.getPrevoutHash(SIGHASH_ALL))
+      })
+    })
+  })
+
+  describe('end to end: flux 2-of-2 P2SH multisig signing', function () {
+    it('signatures made with warm cache verify against cold-instance sighashes', function () {
+      var network = networks.flux
+      var keyPair1 = deterministicKeyPair(1, network)
+      var keyPair2 = deterministicKeyPair(2, network)
+      var pubKeys = [keyPair1.getPublicKeyBuffer(), keyPair2.getPublicKeyBuffer()].sort(function (a, b) {
+        return a.compare(b)
+      })
+      var redeemScript = btemplates.multisig.output.encode(2, pubKeys)
+      var scriptPubKey = btemplates.scriptHash.output.encode(bcrypto.hash160(redeemScript))
+      var numInputs = 20
+
+      var txb = new TransactionBuilder(network)
+      txb.setVersion(4)
+      txb.tx.overwintered = 1
+      txb.tx.versionGroupId = 0x892f2085
+      var i
+      for (i = 0; i < numInputs; i++) {
+        txb.addInput(bcrypto.sha256(Buffer.from('utxo-' + i)).toString('hex'), 0)
+      }
+      txb.addOutput(scriptPubKey, VALUE * numInputs - 10000)
+
+      // sign every input with both keys on the same (cache warm) builder
+      for (i = 0; i < numInputs; i++) {
+        txb.sign(i, keyPair1, redeemScript, SIGHASH_ALL, VALUE)
+        txb.sign(i, keyPair2, redeemScript, SIGHASH_ALL, VALUE)
+      }
+      var tx = txb.build()
+
+      // every signature must verify against the sighash recomputed from
+      // scratch on a cold clone (empty cache) — exactly what network
+      // consensus validation does
+      for (i = 0; i < numInputs; i++) {
+        var coldHash = tx.clone().hashForZcashSignature(i, redeemScript, VALUE, SIGHASH_ALL)
+        var warmHash = tx.hashForZcashSignature(i, redeemScript, VALUE, SIGHASH_ALL)
+        assert.deepStrictEqual(warmHash, coldHash)
+
+        // scriptSig chunks: OP_0, sig1, sig2, redeemScript
+        var scriptChunks = bscript.decompile(tx.ins[i].script)
+        var signatures = scriptChunks.slice(1, -1) // strip leading OP_0 and trailing redeemScript
+        assert.strictEqual(signatures.length, 2)
+        signatures.forEach(function (signature) {
+          var parsed = ECSignature.parseScriptSignature(signature)
+          var verified = pubKeys.some(function (pubKey) {
+            return ECPair.fromPublicKeyBuffer(pubKey, network).verify(coldHash, parsed.signature)
+          })
+          assert.strictEqual(verified, true)
+        })
+      }
+    })
+
+    it('fromTransaction + second-signer flow produces identical tx to single-pass signing', function () {
+      var network = networks.flux
+      var keyPair1 = deterministicKeyPair(3, network)
+      var keyPair2 = deterministicKeyPair(4, network)
+      var pubKeys = [keyPair1.getPublicKeyBuffer(), keyPair2.getPublicKeyBuffer()].sort(function (a, b) {
+        return a.compare(b)
+      })
+      var redeemScript = btemplates.multisig.output.encode(2, pubKeys)
+      var scriptPubKey = btemplates.scriptHash.output.encode(bcrypto.hash160(redeemScript))
+      var numInputs = 10
+
+      function makeBuilder () {
+        var txb = new TransactionBuilder(network)
+        txb.setVersion(4)
+        txb.tx.overwintered = 1
+        txb.tx.versionGroupId = 0x892f2085
+        for (var i = 0; i < numInputs; i++) {
+          txb.addInput(bcrypto.sha256(Buffer.from('utxo-rt-' + i)).toString('hex'), 0)
+        }
+        txb.addOutput(scriptPubKey, VALUE * numInputs - 10000)
+        return txb
+      }
+
+      // single pass: both keys sign on one builder
+      var single = makeBuilder()
+      var i
+      for (i = 0; i < numInputs; i++) {
+        single.sign(i, keyPair1, redeemScript, SIGHASH_ALL, VALUE)
+        single.sign(i, keyPair2, redeemScript, SIGHASH_ALL, VALUE)
+      }
+      var singleHex = single.build().toHex()
+
+      // two pass (the SSP wallet -> key flow): first signer, serialize,
+      // parse on the other side, second signer, finalise
+      var first = makeBuilder()
+      for (i = 0; i < numInputs; i++) {
+        first.sign(i, keyPair1, redeemScript, SIGHASH_ALL, VALUE)
+      }
+      var partialHex = first.buildIncomplete().toHex()
+
+      var second = TransactionBuilder.fromTransaction(Transaction.fromHex(partialHex, network), network)
+      for (i = 0; i < numInputs; i++) {
+        second.sign(i, keyPair2, redeemScript, SIGHASH_ALL, VALUE)
+      }
+      var twoPassHex = second.build().toHex()
+
+      assert.strictEqual(twoPassHex, singleHex)
+    })
+  })
+})


### PR DESCRIPTION
hashPrevouts, hashSequence and hashOutputs commit to all input outpoints, all sequence numbers and all outputs respectively — they are constants of the transaction for a given hashType, yet they were recomputed inside every hashForZcashSignature/hashForWitnessV0/hashForCashSignature call, making multi-input signing O(n^2) in the input count. A 2-of-2 P2SH flux transaction with 2650 inputs took ~12s to sign on desktop V8 and many minutes on mobile (Hermes), freezing the SSP Key app.

Cache the three digests per Transaction instance, keyed by hashType. The SIGHASH_SINGLE outputs digest depends on inIndex and is never cached. Cache is invalidated by addInput/addOutput (the only ins/outs mutation points; the builder also enforces immutability once signatures exist) and exposed via invalidateHashCache() for direct mutations. Getters return defensive copies so callers keep owning the returned buffer, and clone() starts with an empty cache.

Signing the same 2650-input transaction now takes ~1.3s on V8 (9x) and ~3.5s for the 7142-input flux maximum (24x), with byte-identical output (RFC6979 deterministic signatures verified equal).